### PR TITLE
Add version dependency in manifest

### DIFF
--- a/cf-api.psd1
+++ b/cf-api.psd1
@@ -33,7 +33,7 @@ Copyright = '(c) 2019 Philips. All rights reserved.'
 Description = 'CloudFoundry methods for managing spaces'
 
 # Minimum version of the Windows PowerShell engine required by this module
-# PowerShellVersion = ''
+PowerShellVersion = '5.1'
 
 # Name of the Windows PowerShell host required by this module
 # PowerShellHostName = ''
@@ -120,4 +120,3 @@ PrivateData = @{
 # DefaultCommandPrefix = ''
 
 }
-


### PR DESCRIPTION
It's mentioned as PowerShell 5.1 as a dependency hence it's a prerequisite as well. So it's required to be mentioned in the module manifest as well.

https://github.com/philips-software/powershell-cf-api/blob/master/cf-api.psd1#L36 

Cc: @JeroenKnoops 